### PR TITLE
avoid reporting the same error object more than once

### DIFF
--- a/logging-manager.coffee
+++ b/logging-manager.coffee
@@ -19,6 +19,9 @@ module.exports = Logger =
 			attributes = {err: new Error(attributes)}
 		# extract any error object
 		error = attributes.err or attributes.error
+		# avoid reporting errors twice
+		for key, value of attributes
+			return if value instanceof Error && value.reportedToSentry
 		# include our log message in the error report
 		if not error?
 			error = {message: message} if typeof message is 'string'
@@ -50,6 +53,9 @@ module.exports = Logger =
 			# send the error to sentry
 			try
 				@raven.captureException(error, {tags: tags, extra: extra, level: level})
+				# put a flag on the errors to avoid reporting them multiple times
+				for key, value of attributes
+					value.reportedToSentry = true if value instanceof Error
 			catch
 				return # ignore any errors
 

--- a/test/unit/coffee/loggingManagerTests.coffee
+++ b/test/unit/coffee/loggingManagerTests.coffee
@@ -1,3 +1,6 @@
+# run this with 
+# ./node_modules/.bin/mocha --reporter tap --compilers coffee:coffee-script/register test/unit/coffee/loggingManagerTests.coffee
+
 require('coffee-script')
 chai = require('chai')
 should = chai.should()
@@ -24,6 +27,18 @@ describe 'logger.error', ->
 		@logger.error {foo:'bar'}, "message"
 		@captureException.called.should.equal true
 
+	it 'should report the same error to sentry only once', () ->
+		error1 = new Error('this is the error')
+		@logger.error {foo: error1}, "first message"
+		@logger.error {bar: error1}, "second message"
+		@captureException.callCount.should.equal 1
+
+	it 'should report two different errors to sentry individually', () ->
+		error1 = new Error('this is the error')
+		error2 = new Error('this is the error')
+		@logger.error {foo: error1}, "first message"
+		@logger.error {bar: error2}, "second message"
+		@captureException.callCount.should.equal 2
 
 	it 'for multiple errors should only report a maximum of 5 errors to sentry', () ->
 		@logger.error {foo:'bar'}, "message"


### PR DESCRIPTION
I've noticed that we often end up reporting the same error in sentry twice, and the reason is that we first log it with `logger.error err:err, "message"` and then do `callback(err) `which in many services goes to a top-level handler that reports the error again.  

I've made a change to put a `reportedToSentry` flag on `Error` objects so we can avoid reporting them to sentry multiple times.

Example:
This error https://sentry.io/overleaf/sl-project-history-prod/issues/750398561/events/35239980707/
will report the error twice, once as `"failed to stat file in _getBlobHash"` and then as `"an internal error occured"`.

https://github.com/sharelatex/project-history-sharelatex/blob/master/app.coffee#L102-L112
```
app.use (error, req, res, next) ->
	if error instanceof Errors.NotFoundError
		res.send 404
	else if error instanceof Errors.BadRequestError
		res.send 400
	else if error instanceof Errors.InconsistentChunkError
		res.send 422
	else
		logger.error err: error, req: req, "an internal error occured"
		res.status(500).json({error})
```

Deployment note:

 - [ ] increase the package version number here in `package.json` and in project-history to use the new version.

Connects to overleaf/sharelatex#1135