### PR TITLE
remove the path in the message from fs errors

### DIFF
--- a/logging-manager.coffee
+++ b/logging-manager.coffee
@@ -50,6 +50,10 @@ module.exports = Logger =
 				for own key, value of error
 					newError[key] = value
 				error = newError
+			# filter paths from the message to avoid duplicate errors in sentry
+			# (e.g. errors from `fs` methods which have a path attribute)
+			try
+				error.message = error.message.replace(" '#{error.path}'", '') if error.path
 			# send the error to sentry
 			try
 				@raven.captureException(error, {tags: tags, extra: extra, level: level})

--- a/test/unit/coffee/loggingManagerTests.coffee
+++ b/test/unit/coffee/loggingManagerTests.coffee
@@ -40,6 +40,12 @@ describe 'logger.error', ->
 		@logger.error {bar: error2}, "second message"
 		@captureException.callCount.should.equal 2
 
+	it 'should remove the path from fs errors', () ->
+		fsError = new Error("Error: ENOENT: no such file or directory, stat '/tmp/3279b8d0-da10-11e8-8255-efd98985942b'")
+		fsError.path = "/tmp/3279b8d0-da10-11e8-8255-efd98985942b"
+		@logger.error {err: fsError}, "message"
+		@captureException.calledWith(sinon.match.has('message', 'Error: ENOENT: no such file or directory, stat')).should.equal true
+
 	it 'for multiple errors should only report a maximum of 5 errors to sentry', () ->
 		@logger.error {foo:'bar'}, "message"
 		@logger.error {foo:'bar'}, "message"


### PR DESCRIPTION
We get a lot of individual errors where node puts a filename in the error description. Every time one of these occurs it generates a new error like `"ENOENT: file does not exist /tmp/RANDOM_FILE_NAME"` which clutters up sentry.  To consolidate these errors, check for a `path` property on the Error object and remove its contents from the `message`.

Connects to https://github.com/overleaf/sharelatex/issues/1135