### PR TITLE
add process.env['LOG_LEVEL'] varable to let us change the logging level

### DIFF
--- a/logging-manager.coffee
+++ b/logging-manager.coffee
@@ -2,9 +2,11 @@ bunyan = require('bunyan')
 
 module.exports = Logger =
 	initialize: (name) ->
+		level = process.env['LOG_LEVEL'] or "debug"
 		@logger = bunyan.createLogger
 			name: name
 			serializers: bunyan.stdSerializers
+			level: level
 		return @
 
 	initializeErrorReporting: (sentry_dsn, options) ->

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "http://github.com/sharelatex/logger-sharelatex.git"
   },
-  "version": "1.5.8",
+  "version": "1.5.9",
   "dependencies": {
     "bunyan": "1.5.1",
     "chai": "",


### PR DESCRIPTION
related to https://github.com/sharelatex/overleaf-google-ops/issues/110